### PR TITLE
pants: move tooling configuration to pyproject.toml

### DIFF
--- a/pants_from_sources
+++ b/pants_from_sources
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+# Copyright 2020 Pants project contributors.
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+# Runs pants from sources.  Useful for debugging.
+# Assumes you have the pantsbuild/pants repo checked out in a sibling dir of this dir,
+# named 'pants' but overridable using PANTS_SOURCE.
+
+set -euo pipefail
+
+cd "$(git rev-parse --show-toplevel)"
+
+PANTS_SOURCE="${PANTS_SOURCE:-../pants}"
+
+# When running pants from sources you are likely to be modifying those sources, so
+# you won't want pantsd running.  You can override this by setting ENABLE_PANTSD=true.
+ENABLE_PANTSD="${ENABLE_PANTSD:-false}"
+
+export PANTS_VERSION="$(cat "${PANTS_SOURCE}/src/python/pants/VERSION")"
+export PANTS_PANTSD="${ENABLE_PANTSD}"
+export no_proxy="*"
+
+exec "${PANTS_SOURCE}/pants" "--no-verify-config" "$@"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,10 @@
+[tool.mypy]
+ignore_missing_imports = true
+
+# isort configuration stored in the `setup.cfg` with the `cheeseshop` added
+# as the known first party doesn't respect the import order on `setup.py`
+# and running `./pants fmt lint ::` results in isort failure;
+[tool.isort]
+profile = "black"
+line_length = 88
+known_first_party = ["internal_plugins", "cheeseshop"]

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,10 +1,2 @@
 [flake8]
 max-line-length = 88
-
-[mypy]
-ignore_missing_imports = True
-
-[isort]
-profile = black
-line_length = 88
-known_first_party = internal_plugins


### PR DESCRIPTION
Start using `pyproject.toml` for some of the tools.