### PR TITLE
plugins: add deps_group plugin

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -26,3 +26,13 @@ python_distribution(
     sdist=False,
     generate_setup=False,
 )
+
+deps_group(
+    name="deps-group-1",
+    source="deps-grouping.json",
+)
+
+deps_group(
+    name="deps-group-2",
+    source="deps-grouping.json",
+)

--- a/cheeseshop/BUILD
+++ b/cheeseshop/BUILD
@@ -1,6 +1,6 @@
 python_sources(
     overrides={
-        "version.py": {"dependencies": ["//:deps-group-1"]},
+        "version.py": {"dependencies": ["//:deps-group-2"]},
     }
 )
 

--- a/cheeseshop/BUILD
+++ b/cheeseshop/BUILD
@@ -1,4 +1,8 @@
-python_sources()
+python_sources(
+    overrides={
+        "version.py": {"dependencies": ["//:deps-group-1"]},
+    }
+)
 
 resource(
     name="project-version",

--- a/cheeseshop/version.py
+++ b/cheeseshop/version.py
@@ -1,5 +1,7 @@
 import pkgutil
 
+import dateutil
+
 VERSION: str = (
     pkgutil.get_data(__name__, "VERSION").decode().strip()  # type: ignore[union-attr]
 )

--- a/deps-grouping.json
+++ b/deps-grouping.json
@@ -1,4 +1,4 @@
 {
-  "deps-group-1": ["click", "loguru"],
+  "deps-group-1": ["click", "loguru", "setuptools"],
   "deps-group-2": ["requests"]
 }

--- a/deps-grouping.json
+++ b/deps-grouping.json
@@ -1,0 +1,4 @@
+{
+  "deps-group-1": ["click", "loguru"],
+  "deps-group-2": ["requests"]
+}

--- a/pants-plugins/internal_plugins/deps_grouping/BUILD
+++ b/pants-plugins/internal_plugins/deps_grouping/BUILD
@@ -1,0 +1,4 @@
+python_sources(
+    name="pants-plugins",
+    resolve="pants-plugins",
+)

--- a/pants-plugins/internal_plugins/deps_grouping/register.py
+++ b/pants-plugins/internal_plugins/deps_grouping/register.py
@@ -1,0 +1,16 @@
+from typing import Iterable
+
+from pants.engine.target import Target
+
+import internal_plugins.deps_grouping.rules as deps_grouping_rules
+from internal_plugins.deps_grouping.target_types import DepsGroupTarget
+
+
+def target_types() -> Iterable[type[Target]]:
+    return [DepsGroupTarget]
+
+
+def rules():
+    return [
+        *deps_grouping_rules.rules(),
+    ]

--- a/pants-plugins/internal_plugins/deps_grouping/rules.py
+++ b/pants-plugins/internal_plugins/deps_grouping/rules.py
@@ -1,0 +1,108 @@
+import json
+from dataclasses import dataclass
+
+import logging
+
+from pants.backend.python.dependency_inference.rules import InferPythonImportDependencies, \
+    PythonImportDependenciesInferenceFieldSet
+from pants.backend.python.target_types import PythonDependenciesField
+from pants.engine.addresses import Addresses, UnparsedAddressInputs
+from pants.util.ordered_set import FrozenOrderedSet
+
+logger = logging.getLogger(__name__)
+
+from pants.build_graph.address import Address
+from pants.engine.fs import DigestContents
+from pants.engine.internals.native_engine import Digest
+from pants.engine.internals.selectors import Get, MultiGet
+from pants.engine.rules import collect_rules, rule
+from pants.engine.target import (
+    FieldSet,
+    HydratedSources,
+    HydrateSourcesRequest,
+    InferDependenciesRequest,
+    InferredDependencies, Targets, DependenciesRequest, Dependencies,
+)
+from pants.engine.unions import UnionRule
+
+from internal_plugins.deps_grouping.target_types import (
+    DepsGroupSourceField,
+)
+
+
+@dataclass(frozen=True)
+class DepsGroupsFileView:
+    path: str
+    contents: str
+
+
+@dataclass(frozen=True)
+class DepsGroupDependencyInferenceFieldSet(FieldSet):
+    required_fields = (DepsGroupSourceField,)
+
+    source: DepsGroupSourceField
+
+
+class InferDepsGroupDependenciesRequest(InferDependenciesRequest):
+    infer_from = DepsGroupDependencyInferenceFieldSet
+
+
+@rule
+async def extend_dependencies(
+    request: InferDepsGroupDependenciesRequest,
+) -> InferredDependencies:
+    sources = await Get(
+        HydratedSources, HydrateSourcesRequest(request.field_set.source)
+    )
+    digest_contents = await Get(DigestContents, Digest, sources.snapshot.digest)
+    file_content = digest_contents[0]
+    requirements = json.loads(file_content.content.decode("utf-8").strip())
+
+    addresses = []
+    for req in requirements[request.field_set.address.target_name]:
+        addresses.append(
+            Address("requirements", target_name="requirements", generated_name=req),
+        )
+
+    return InferredDependencies(addresses)
+
+
+class MyDependencies(Dependencies):
+    pass
+
+
+@dataclass(frozen=True)
+class MyFieldSet(FieldSet):
+    required_fields = (
+        PythonDependenciesField,
+    )
+    dependencies: PythonDependenciesField
+
+
+class MyInferDependenciesRequest(InferDependenciesRequest):
+    infer_from = MyFieldSet
+
+
+@rule
+async def get_dependencies_python_sources(
+    request: MyInferDependenciesRequest,
+) -> InferredDependencies:
+    # logger.info(request.field_set.dependencies)
+    for dep_string in request.field_set.dependencies.value:
+        targets = await Get(Targets, UnparsedAddressInputs([dep_string], owning_address=None, description_of_origin="me"))
+        for target in targets:
+            logger.info(target)
+            logger.info(type(target))
+            # this doesn't work - the matching rule can't be found
+            # deps = await Get(Addresses, InferDepsGroupDependenciesRequest(target.get(Dependencies)))
+            # logger.info(deps)
+
+    return InferredDependencies([])
+
+
+def rules():
+    return (
+        *collect_rules(),
+        UnionRule(InferDependenciesRequest, InferDepsGroupDependenciesRequest),
+        UnionRule(InferDependenciesRequest, MyInferDependenciesRequest),
+    )

--- a/pants-plugins/internal_plugins/deps_grouping/rules.py
+++ b/pants-plugins/internal_plugins/deps_grouping/rules.py
@@ -1,32 +1,31 @@
 import json
+import logging
 from dataclasses import dataclass
 
-import logging
-
-from pants.backend.python.dependency_inference.rules import InferPythonImportDependencies, \
-    PythonImportDependenciesInferenceFieldSet
 from pants.backend.python.target_types import PythonDependenciesField
 from pants.engine.addresses import Addresses, UnparsedAddressInputs
-from pants.util.ordered_set import FrozenOrderedSet
+
 
 logger = logging.getLogger(__name__)
 
 from pants.build_graph.address import Address
 from pants.engine.fs import DigestContents
 from pants.engine.internals.native_engine import Digest
-from pants.engine.internals.selectors import Get, MultiGet
+from pants.engine.internals.selectors import Get
 from pants.engine.rules import collect_rules, rule
 from pants.engine.target import (
     FieldSet,
     HydratedSources,
     HydrateSourcesRequest,
     InferDependenciesRequest,
-    InferredDependencies, Targets, DependenciesRequest, Dependencies,
+    InferredDependencies,
+    Targets,
 )
 from pants.engine.unions import UnionRule
 
 from internal_plugins.deps_grouping.target_types import (
     DepsGroupSourceField,
+    DepsGroupTarget,
 )
 
 
@@ -47,10 +46,11 @@ class InferDepsGroupDependenciesRequest(InferDependenciesRequest):
     infer_from = DepsGroupDependencyInferenceFieldSet
 
 
-@rule
+@rule("Get dependencies of a deps_group target.")
 async def extend_dependencies(
     request: InferDepsGroupDependenciesRequest,
 ) -> InferredDependencies:
+    """This rule is used when running `pants dependencies //:deps-group-1`."""
     sources = await Get(
         HydratedSources, HydrateSourcesRequest(request.field_set.source)
     )
@@ -67,42 +67,76 @@ async def extend_dependencies(
     return InferredDependencies(addresses)
 
 
-class MyDependencies(Dependencies):
-    pass
+@dataclass
+class RequirementsAddresses:
+    """List of addresses to python_requirement targets."""
+
+    addresses: list[Address]
+
+
+@rule("Read requirements from JSON file.")
+async def read_deps_group_target_requirements_from_json_file(
+    target: DepsGroupTarget,
+) -> RequirementsAddresses:
+    """This rule is used to get requirements of a given `deps_group` target
+    from a JSON file."""
+    sources = await Get(
+        HydratedSources, HydrateSourcesRequest(target.get(DepsGroupSourceField))
+    )
+    digest_contents = await Get(DigestContents, Digest, sources.snapshot.digest)
+    file_content = digest_contents[0]
+    requirements = json.loads(file_content.content.decode("utf-8").strip())
+
+    addresses = []
+    for req in requirements[target.address.target_name]:
+        addresses.append(
+            Address("requirements", target_name="requirements", generated_name=req),
+        )
+    return RequirementsAddresses(addresses=addresses)
 
 
 @dataclass(frozen=True)
-class MyFieldSet(FieldSet):
-    required_fields = (
-        PythonDependenciesField,
-    )
+class PythonSourcesExtensionFieldSet(FieldSet):
+    """Extension of python sources field set to be used in a custom dependency
+    inference request."""
+
+    required_fields = (PythonDependenciesField,)
     dependencies: PythonDependenciesField
 
 
-class MyInferDependenciesRequest(InferDependenciesRequest):
-    infer_from = MyFieldSet
+class PythonSourcesExtensionInferDependenciesRequest(InferDependenciesRequest):
+    infer_from = PythonSourcesExtensionFieldSet
 
 
-@rule
-async def get_dependencies_python_sources(
-    request: MyInferDependenciesRequest,
+@rule(
+    "Get Python requirements that a Python source module depends on via a dependency group."
+)
+async def get_dep_group_dependencies_python_sources(
+    request: PythonSourcesExtensionInferDependenciesRequest,
 ) -> InferredDependencies:
-    # logger.info(request.field_set.dependencies)
+    all_requirements_addresses = []
     for dep_string in request.field_set.dependencies.value:
-        targets = await Get(Targets, UnparsedAddressInputs([dep_string], owning_address=None, description_of_origin="me"))
+        targets = await Get(
+            Targets,
+            UnparsedAddressInputs(
+                [dep_string],
+                owning_address=None,
+                description_of_origin="pants-plugins",
+            ),
+        )
         for target in targets:
-            logger.info(target)
-            logger.info(type(target))
-            # this doesn't work - the matching rule can't be found
-            # deps = await Get(Addresses, InferDepsGroupDependenciesRequest(target.get(Dependencies)))
-            # logger.info(deps)
+            requirements = await Get(RequirementsAddresses, DepsGroupTarget, target)
+            for req in requirements.addresses:
+                all_requirements_addresses.append(req)
 
-    return InferredDependencies([])
+    return InferredDependencies(Addresses(all_requirements_addresses))
 
 
 def rules():
     return (
         *collect_rules(),
         UnionRule(InferDependenciesRequest, InferDepsGroupDependenciesRequest),
-        UnionRule(InferDependenciesRequest, MyInferDependenciesRequest),
+        UnionRule(
+            InferDependenciesRequest, PythonSourcesExtensionInferDependenciesRequest
+        ),
     )

--- a/pants-plugins/internal_plugins/deps_grouping/target_types.py
+++ b/pants-plugins/internal_plugins/deps_grouping/target_types.py
@@ -1,0 +1,13 @@
+from pants.engine.target import COMMON_TARGET_FIELDS, SingleSourceField, Target
+
+
+class DepsGroupSourceField(SingleSourceField):
+    alias = "source"
+    help = "Path to the file with the dependency groups."
+    required = True
+
+
+class DepsGroupTarget(Target):
+    alias = "deps_group"
+    core_fields = (*COMMON_TARGET_FIELDS, DepsGroupSourceField)
+    help = "A dependency group target with access to dependency groups stored in a given file."

--- a/pants.toml
+++ b/pants.toml
@@ -17,6 +17,7 @@ backend_packages = [
   # plugins
   "pants.backend.plugin_development",
   "internal_plugins.project_version",
+  "internal_plugins.deps_grouping",
 ]
 
 plugins = ["packaging==21.3"]


### PR DESCRIPTION
```
❯ pants dependencies //:deps-group-1
requirements#click
requirements#loguru
```

Works great.

```
❯ pants --no-pantsd --no-local-cache dependencies cheeseshop/version.py
23:18:15.67 [INFO] deps_group(address="//:deps-group-1", description=None, source=deps-grouping.json, tags=None)
23:18:15.67 [INFO] <class 'internal_plugins.deps_grouping.target_types.DepsGroupTarget'>
//:deps-group-1
```

Works great.

What's left is to query the dependencies of `"//:deps-group-1"` and report in the terminal.

But if uncomment 

https://github.com/AlexTereshenkov/cheeseshop-query/pull/32/files#diff-4ad71084fd132de6ce6e5a97ddada00df3664bcf6d4d977463be0d11ef7716a0R97

```
# deps = await Get(Addresses, InferDepsGroupDependenciesRequest(target.get(Dependencies)))
```

Pants can't find a matching rule.