### PR TITLE
pex: rely on system site-packages for RPM packages installed

### DIFF
--- a/pants.toml
+++ b/pants.toml
@@ -86,3 +86,6 @@ args = ["-v", "--vcr-record=none"]
 
 [tailor]
 ignore_paths = ["requirements/BUILD"]
+
+[pex]
+verbosity = 9

--- a/requirements/BUILD
+++ b/requirements/BUILD
@@ -15,3 +15,13 @@ python_requirements(
     source="requirements-dev.txt",
     resolve="devtools",
 )
+
+python_requirement(
+    name="python-requirement",
+    modules=[
+        "tabulate",
+    ],
+    requirements=[
+        "python3-tabulate",
+    ],
+)

--- a/requirements/requirements.lock
+++ b/requirements/requirements.lock
@@ -17,7 +17,8 @@
 //     "setuptools",
 //     "types-python-dateutil",
 //     "types-requests",
-//     "typing-extensions"
+//     "typing-extensions",
+//     "python3-tabulate"
 //   ],
 //   "manylinux": "manylinux2014",
 //   "requirement_constraints": [],
@@ -156,6 +157,19 @@
           ],
           "requires_python": ">=3.7",
           "version": "8.1.7"
+        },
+        {
+          "artifacts": [
+            {
+              "algorithm": "sha256",
+              "hash": "ae74fb96c20a0277a1d615f1e4d73c8414f5a98db8b799a7931d1582f3390c28",
+              "url": "https://files.pythonhosted.org/packages/00/2e/d53fa4befbf2cfa713304affc7ca780ce4fc1fd8710527771b58311a3229/click-8.1.7-py3-none-any.whl"
+            }
+          ],
+          "project_name": "python3-tabulate",
+          "requires_dists": [],
+          "requires_python": ">=3.7",
+          "version": "9999"
         },
         {
           "artifacts": [
@@ -460,7 +474,8 @@
     "setuptools",
     "types-python-dateutil",
     "types-requests",
-    "typing-extensions"
+    "typing-extensions",
+    "python3-tabulate"
   ],
   "requires_python": [
     "<3.10,>=3.9"

--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -7,3 +7,4 @@ setuptools
 typing-extensions
 types-python-dateutil
 types-requests
+python3-tabulate

--- a/tests/cli/BUILD
+++ b/tests/cli/BUILD
@@ -4,6 +4,7 @@ python_tests(
         "cheeseshop:project-version",
         ":cassettes",
     ],
+    extra_env_vars=["PEX_EXTRA_SYS_PATH"]
 )
 
 resources(

--- a/tests/cli/test_cli.py
+++ b/tests/cli/test_cli.py
@@ -1,11 +1,14 @@
 import pytest
 from click.testing import CliRunner
 
+import tabulate
 from cheeseshop.cli import cli
 from cheeseshop.version import VERSION
 
 
 def test_cli():
+
+    assert tabulate.tabulate("") == ""
     runner = CliRunner()
     result = runner.invoke(cli.cli, ["--version"])
     assert result.exit_code == 0


### PR DESCRIPTION
```
$ PEX_EXTRA_SYS_PATH="/home/user.name/local/lib/python3.11/site-packages" pants --no-local-cache test tests/cli
```