### PR TITLE
pex: rely on system site-packages for RPM packages installed - no manual editing of lockfile

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -26,3 +26,16 @@ python_distribution(
     sdist=False,
     generate_setup=False,
 )
+
+python_requirement(
+    name="python3-tabulate",
+    modules=[
+        "tabulate",
+    ],
+    requirements=[
+        "python3-tabulate",
+    ],
+    tags=[
+        "provided",
+    ],
+)

--- a/cheeseshop/cli/cli.py
+++ b/cheeseshop/cli/cli.py
@@ -1,5 +1,7 @@
 import sys
 
+import tabulate
+
 import click
 from loguru import logger
 

--- a/cheeseshop/cli/utils/utils.py
+++ b/cheeseshop/cli/utils/utils.py
@@ -3,6 +3,7 @@ from collections.abc import Iterable
 # forbidden import
 # from cheeseshop.repository.parsing.casts import from_none
 
+import tabulate
 
 def choices(option_type: Iterable) -> list[str]:
     """Get click option choices from an iterable."""

--- a/cheeseshop/version.py
+++ b/cheeseshop/version.py
@@ -1,5 +1,7 @@
 import pkgutil
 
+import tabulate
+
 VERSION: str = (
     pkgutil.get_data(__name__, "VERSION").decode().strip()  # type: ignore[union-attr]
 )

--- a/tests/cli/BUILD
+++ b/tests/cli/BUILD
@@ -4,6 +4,7 @@ python_tests(
         "cheeseshop:project-version",
         ":cassettes",
     ],
+    extra_env_vars=["PEX_EXTRA_SYS_PATH"]
 )
 
 resources(

--- a/tests/cli/test_cli.py
+++ b/tests/cli/test_cli.py
@@ -4,8 +4,10 @@ from click.testing import CliRunner
 from cheeseshop.cli import cli
 from cheeseshop.version import VERSION
 
+import tabulate
 
 def test_cli():
+    assert tabulate.tabulate("") == ""
     runner = CliRunner()
     result = runner.invoke(cli.cli, ["--version"])
     assert result.exit_code == 0


### PR DESCRIPTION
```
23:24:38.61 [INFO] Canceled: Building 9 requirements for requirements.pex from the requirements/requirements.lock resolve: click, loguru, packaging, python-dateutil, python3-tabulate, requests, types-python-dateutil, types-reques... (21 characters truncated)
23:24:39.41 [INFO] Completed: Building 9 requirements for requirements.pex from the requirements/requirements.lock resolve: click, loguru, packaging, python-dateutil, python3-tabulate, requests, types-python-dateutil, types-reques... (21 characters truncated)
23:24:39.42 [ERROR] 1 Exception encountered:

Engine traceback:
  in `test` goal

ProcessExecutionFailure: Process 'Building 9 requirements for requirements.pex from the requirements/requirements.lock resolve: click, loguru, packaging, python-dateutil, python3-tabulate, requests, types-python-dateutil, types-requests, typing-extensions' failed with exit code 1.
stdout:

stderr:
Failed to resolve compatible artifacts from lock requirements/requirements.lock for 1 target:
1. /usr/bin/python3.9:
    Failed to resolve all requirements for cp39-cp39-manylinux_2_36_x86_64 interpreter at /usr/bin/python3.9 from requirements/requirements.lock:

Configured with:
    build: True
    use_wheel: True

Dependency on python3-tabulate (via: python3-tabulate) not satisfied, no candidates found.
```