### PR TITLE
Make tests depend on custom target

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -17,7 +17,7 @@ python_distribution(
     dependencies=[
         ":setup-py",
         ":MANIFEST",
-        "cheeseshop:project-version",
+        #"cheeseshop:project-version",
         "cheeseshop/cli:cheeseshop-query",
     ],
     provides=python_artifact(

--- a/cheeseshop/BUILD
+++ b/cheeseshop/BUILD
@@ -1,9 +1,9 @@
 python_sources()
-
-resource(
-    name="project-version",
-    source="VERSION",
-)
+#
+#resource(
+#    name="project-version",
+#    source="VERSION",
+#)
 
 version_file(
     name="main-project-version",

--- a/cheeseshop/cli/BUILD
+++ b/cheeseshop/cli/BUILD
@@ -5,5 +5,5 @@ pex_binary(
 
 python_sources(
     name="cli",
-    dependencies=["cheeseshop:project-version"],
+    #dependencies=["cheeseshop:project-version"],
 )

--- a/tests/cli/BUILD
+++ b/tests/cli/BUILD
@@ -1,7 +1,8 @@
 python_tests(
     name="tests",
     dependencies=[
-        "cheeseshop:project-version",
+        #"cheeseshop:project-version",
+        "cheeseshop:main-project-version",
         ":cassettes",
     ],
 )

--- a/tests/cli/test_cli.py
+++ b/tests/cli/test_cli.py
@@ -1,38 +1,4 @@
 import pytest
-from click.testing import CliRunner
-
-from cheeseshop.cli import cli
-from cheeseshop.version import VERSION
-
 
 def test_cli():
-    runner = CliRunner()
-    result = runner.invoke(cli.cli, ["--version"])
-    assert result.exit_code == 0
-    assert VERSION in result.output
-
-
-@pytest.mark.vcr()
-def test_cli_info():
-    runner = CliRunner()
-    result = runner.invoke(cli.cli, ["info", "--package", "packaging"])
-    assert result.exit_code == 0
-    assert "Core utilities for Python packages" in result.output
-
-
-@pytest.mark.vcr()
-def test_cli_list_versions():
-    runner = CliRunner()
-    result = runner.invoke(
-        cli.cli,
-        [
-            "list-versions",
-            "--package=numpy",
-            "--python-version=cp38",
-            "--package-type=bdist_wheel",
-            "--platform=macos",
-            "--arch=x86_64",
-        ],
-    )
-    assert result.exit_code == 0
-    assert "numpy==1.17.3" in result.output
+    assert True


### PR DESCRIPTION
Repro: modifying file contents of a custom target that owns that file doesn't cause the test to re-run and uses the local cache. 

```
❯ pants test tests/cli                                                                                               
17:15:30.50 [INFO] Completed: Run Pytest - tests/cli/test_cli.py:tests - succeeded.

✓ tests/cli/test_cli.py:tests succeeded in 0.21s (memoized).

❯ echo "0.0.2" > cheeseshop/VERSION

❯ pants test tests/cli
17:15:59.80 [INFO] Completed: Run Pytest - tests/cli/test_cli.py:tests - succeeded.

✓ tests/cli/test_cli.py:tests succeeded in 0.21s (memoized).

❯ echo "11223344" > cheeseshop/VERSION

fedora in ~/code/cheeseshop-query on  caching/custom-targets [$!?] via 🐍 v3.11.3 (.venv) 
❯ pants test tests/cli
17:16:17.02 [INFO] Completed: Run Pytest - tests/cli/test_cli.py:tests - succeeded.

✓ tests/cli/test_cli.py:tests succeeded in 0.21s (memoized).
